### PR TITLE
Rename the shared library

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 # Note: plugindir is set in configure
 
-plugin_LTLIBRARIES = libsnapshotplugin.la
+plugin_LTLIBRARIES = libsnapshotfilter.la
 
 # Path to installation of the output SDK 
 #SNAPSHOT_CFLAGS = 
@@ -10,13 +10,13 @@ GTK_CFLAGS = `pkg-config --cflags gtk+-3.0`
 GTK_LIBS = `pkg-config --libs gtk+-3.0`
 
 # sources used to compile this plug-in
-libsnapshotplugin_la_SOURCES = gstsnapshotfilter.c gstsnapshotfilter.h
+libsnapshotfilter_la_SOURCES = gstsnapshotfilter.c gstsnapshotfilter.h
 
 # compiler and linker flags used to compile this plugin, set in configure.ac
-libsnapshotplugin_la_CFLAGS = $(GST_CFLAGS) $(GTK_CFLAGS)
-libsnapshotplugin_la_LIBADD = $(GST_LIBS) -lgstvideo-1.0 $(SNAPSHOT_LIBS)
-libsnapshotplugin_la_LDFLAGS = $(GST_PLUGIN_LDFLAGS) $(GTK_LIBS) -rpath /usr/local/lib
-libsnapshotplugin_la_LIBTOOLFLAGS = --tag=disable-static
+libsnapshotfilter_la_CFLAGS = $(GST_CFLAGS) $(GTK_CFLAGS)
+libsnapshotfilter_la_LIBADD = $(GST_LIBS) -lgstvideo-1.0 $(SNAPSHOT_LIBS)
+libsnapshotfilter_la_LDFLAGS = $(GST_PLUGIN_LDFLAGS) $(GTK_LIBS) -rpath /usr/local/lib
+libsnapshotfilter_la_LIBTOOLFLAGS = --tag=disable-static
 
 # headers we need but don't want installed
 noinst_HEADERS = gstsnapshotfilter.h


### PR DESCRIPTION
On GStreamer 1.14 the default plugin entry point has changed,
plugins must have matching plugin names in GST_PLUGIN_DEFINE and filenames

fixes #3 